### PR TITLE
Fix OnGUI state display for destroyed targets

### DIFF
--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -87,7 +87,7 @@ public class PlayerController : MonoBehaviour
     private void OnGUI()
     {
         GUI.Label(new Rect(10, 10, 200, 20), "Current State: " + stateMachine.CurrentState.GetType().Name);
-        GUI.Label(new Rect(10, 30, 200, 20), "Current Interaction: " + currentTarget ?? "null");
+        GUI.Label(new Rect(10, 30, 200, 20), "Current Interaction: " + (currentTarget != null ? currentTarget.name : "null"));
         GUI.Label(new Rect(10, 50, 200, 20), "Position: " + transform.position);
         GUI.Label(new Rect(10, 70, 200, 20), "FPS: " + (int)(1f / Time.unscaledDeltaTime));
         


### PR DESCRIPTION
## Summary
- fix `OnGUI` null-coalescing logic

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841f1ed04ec83298f4a4ad7e7976e08