### PR TITLE
Add NPC basic needs and new tasks

### DIFF
--- a/Assets/Scripts/NPC/EatTask.cs
+++ b/Assets/Scripts/NPC/EatTask.cs
@@ -1,0 +1,25 @@
+using System.Linq;
+using DefaultNamespace.Items;
+using DefaultNamespace.NPC;
+using UnityEngine;
+
+public class EatTask : ITask
+{
+    public TaskStatus Execute(NpcController npc)
+    {
+        var food = npc.Inventory.FirstOrDefault(i => i.Item.itemType == ItemType.Consumable);
+        if (food == null)
+        {
+            return TaskStatus.Failure;
+        }
+
+        food.Amount--;
+        if (food.Amount <= 0)
+        {
+            npc.Inventory.Remove(food);
+        }
+
+        npc.hunger = Mathf.Max(0f, npc.hunger - npc.hungerDecreaseAmount);
+        return TaskStatus.Success;
+    }
+}

--- a/Assets/Scripts/NPC/NpcController.cs
+++ b/Assets/Scripts/NPC/NpcController.cs
@@ -18,6 +18,16 @@ namespace DefaultNamespace.NPC
         
         public List<NpcInventoryItem> Inventory = new List<NpcInventoryItem>();
 
+        // Basic needs
+        public float energy = 100f;
+        public float hunger = 0f;
+        public float maxEnergy = 100f;
+        public float maxHunger = 100f;
+        public float energyDecayRate = 5f;
+        public float hungerIncreaseRate = 5f;
+        public float energyRecoveryRate = 20f;
+        public float hungerDecreaseAmount = 40f;
+
         private void Start()
         {
             if (npcJob == NpcJob.Woodcutter)
@@ -34,38 +44,60 @@ namespace DefaultNamespace.NPC
 
         private void Update()
         {
-            if (Tasks.Count == 0)
+            // update needs
+            hunger = Mathf.Min(maxHunger, hunger + hungerIncreaseRate * Time.deltaTime);
+            if (Tasks.Count == 0 || Tasks.First() is not SleepTask)
             {
-                return;
+                energy = Mathf.Max(0f, energy - energyDecayRate * Time.deltaTime);
             }
-            
+
+            // insert high priority tasks based on needs
+            if (energy <= 20f && (Tasks.Count == 0 || Tasks.First() is not SleepTask))
+            {
+                Tasks.Insert(0, new SleepTask());
+            }
+            else if (hunger >= 80f && (Tasks.Count == 0 || Tasks.First() is not EatTask))
+            {
+                Tasks.Insert(0, new EatTask());
+            }
+
+            if (!Tasks.Any())
+            {
+                AddDefaultTask();
+            }
+
             var current = Tasks.First();
             var status  = current.Execute(this);
 
             if (status == TaskStatus.Success)
             {
-                if (npcJob == NpcJob.Woodcutter)
-                {
-                    Tasks.Remove(current);
-                    if (!Tasks.Any())
-                    {
-                        Tasks.Add(new ChopTreeTask());
-                    }
-                }
-                else if (npcJob == NpcJob.Chicken && !Tasks.Any())
-                {
-                    Tasks.Remove(current);
-
-                    if (!Tasks.Any())
-                    {
-                        var newPosition = new Vector2(transform.position.x + Random.Range(-10, 10), transform.position.y + Random.Range(-10, 10));
-                        Tasks.Add(new MoveToTask(newPosition));
-                    }
-                }
+                Tasks.Remove(current);
             }
             else if (status == TaskStatus.Failure)
             {
                 Tasks.Clear();
+            }
+
+            if (!Tasks.Any())
+            {
+                AddDefaultTask();
+            }
+        }
+
+        private void AddDefaultTask()
+        {
+            if (npcJob == NpcJob.Woodcutter)
+            {
+                Tasks.Add(new ChopTreeTask());
+            }
+            else if (npcJob == NpcJob.Chicken)
+            {
+                var newPosition = new Vector2(transform.position.x + Random.Range(-10, 10), transform.position.y + Random.Range(-10, 10));
+                Tasks.Add(new MoveToTask(newPosition));
+            }
+            else
+            {
+                Tasks.Add(new SocializeTask());
             }
         }
     }

--- a/Assets/Scripts/NPC/SleepTask.cs
+++ b/Assets/Scripts/NPC/SleepTask.cs
@@ -1,0 +1,17 @@
+using DefaultNamespace.NPC;
+using UnityEngine;
+
+public class SleepTask : ITask
+{
+    public TaskStatus Execute(NpcController npc)
+    {
+        npc.energy = Mathf.Min(npc.maxEnergy, npc.energy + npc.energyRecoveryRate * Time.deltaTime);
+
+        if (npc.energy >= npc.maxEnergy)
+        {
+            return TaskStatus.Success;
+        }
+
+        return TaskStatus.Running;
+    }
+}

--- a/Assets/Scripts/NPC/SocializeTask.cs
+++ b/Assets/Scripts/NPC/SocializeTask.cs
@@ -1,0 +1,37 @@
+using DefaultNamespace.NPC;
+using UnityEngine;
+using Random = UnityEngine.Random;
+
+public class SocializeTask : ITask
+{
+    private MoveToTask moveTask;
+    private float socializeDuration = 2f;
+    private float startTime = -1f;
+
+    public TaskStatus Execute(NpcController npc)
+    {
+        if (moveTask == null)
+        {
+            var offset = new Vector2(Random.Range(-3f, 3f), Random.Range(-3f, 3f));
+            moveTask = new MoveToTask((Vector2)npc.transform.position + offset);
+        }
+
+        var status = moveTask.Execute(npc);
+        if (status != TaskStatus.Success)
+        {
+            return status;
+        }
+
+        if (startTime < 0f)
+        {
+            startTime = Time.time;
+        }
+
+        if (Time.time - startTime >= socializeDuration)
+        {
+            return TaskStatus.Success;
+        }
+
+        return TaskStatus.Running;
+    }
+}


### PR DESCRIPTION
## Summary
- expand `NpcController` with energy & hunger values
- add `SleepTask`, `EatTask`, and `SocializeTask`
- update NPC update loop to prioritize needs and default tasks

## Testing
- `dotnet test` *(fails: `dotnet` not found)*
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f8880b908329b1b1e4fb0bd2b4cd